### PR TITLE
[Feat] 아이템 스폰 수정 및 사다리, 순간 이동 버그 픽스

### DIFF
--- a/Assets/LTH/Prefabs/ItemTest1.asset
+++ b/Assets/LTH/Prefabs/ItemTest1.asset
@@ -1,0 +1,22 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7567cf3238682da98bdaeed661d52583, type: 3}
+  m_Name: ItemTest1
+  m_EditorClassIdentifier: 
+  itemName: Test1
+  image: {fileID: 21300000, guid: ba886817d0b1a0251bb01e0afd3beec5, type: 3}
+  prefab: {fileID: 5119693397794912994, guid: 96e73376a437c5d4288ffad9d72d2651, type: 3}
+  description: 
+  recipes: []
+  efficacy:
+  - Stat: 0
+    Amount: 50

--- a/Assets/LTH/Prefabs/ItemTest1.asset.meta
+++ b/Assets/LTH/Prefabs/ItemTest1.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b1a993f0fd1075649840f7f536a3df9e
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/LTH/Prefabs/ItemTest1.prefab
+++ b/Assets/LTH/Prefabs/ItemTest1.prefab
@@ -1,0 +1,120 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &5119693397794912994
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8497546644876033116}
+  - component: {fileID: 8068338901419865356}
+  - component: {fileID: 4406746469269320820}
+  - component: {fileID: 8119580182512754916}
+  - component: {fileID: 2882536750446119815}
+  m_Layer: 6
+  m_Name: ItemTest1
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8497546644876033116
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5119693397794912994}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -1.086, y: 0.133, z: -2.853}
+  m_LocalScale: {x: 0.2, y: 0.2, z: 0.2}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &8068338901419865356
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5119693397794912994}
+  m_Mesh: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &4406746469269320820
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5119693397794912994}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 02bff32342d5e5140b4a80a2b3cb8df8, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!135 &8119580182512754916
+SphereCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5119693397794912994}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Radius: 0.5
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!114 &2882536750446119815
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5119693397794912994}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d48f99de9760f91c997b765bdda73bb4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Assets/LTH/Prefabs/ItemTest1.prefab.meta
+++ b/Assets/LTH/Prefabs/ItemTest1.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 96e73376a437c5d4288ffad9d72d2651
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/LTH/Prefabs/ItemTest2.asset
+++ b/Assets/LTH/Prefabs/ItemTest2.asset
@@ -1,0 +1,21 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1a9cdb8d5d09f8e69ac435b4f545c8bf, type: 3}
+  m_Name: ItemTest2
+  m_EditorClassIdentifier: 
+  itemName: Test2
+  image: {fileID: 21300000, guid: 8bdfa67b51c030fd98def7968a493c8a, type: 3}
+  prefab: {fileID: 4907931070248181609, guid: 77697984206cff6499d94677d6221bd7, type: 3}
+  description: 
+  recipes: []
+  isWeapon: 1
+  mounting: 0

--- a/Assets/LTH/Prefabs/ItemTest2.asset.meta
+++ b/Assets/LTH/Prefabs/ItemTest2.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 290b5e5916cfb1644b8e6e671124d4f5
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/LTH/Prefabs/ItemTest2.prefab
+++ b/Assets/LTH/Prefabs/ItemTest2.prefab
@@ -1,0 +1,120 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &4907931070248181609
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5638360483196550230}
+  - component: {fileID: 6014114756395087121}
+  - component: {fileID: 612578458394699926}
+  - component: {fileID: 2402194619589133249}
+  - component: {fileID: -1686211681044864805}
+  m_Layer: 6
+  m_Name: ItemTest2
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5638360483196550230
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4907931070248181609}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -0.32, y: 0.133, z: -2.853}
+  m_LocalScale: {x: 0.2, y: 0.2, z: 0.2}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &6014114756395087121
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4907931070248181609}
+  m_Mesh: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &612578458394699926
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4907931070248181609}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 34c97111f20e83c409edccc36ce64b17, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!135 &2402194619589133249
+SphereCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4907931070248181609}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Radius: 0.5
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!114 &-1686211681044864805
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4907931070248181609}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d48f99de9760f91c997b765bdda73bb4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Assets/LTH/Prefabs/ItemTest2.prefab.meta
+++ b/Assets/LTH/Prefabs/ItemTest2.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 77697984206cff6499d94677d6221bd7
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/LTH/Prefabs/Ladder.prefab
+++ b/Assets/LTH/Prefabs/Ladder.prefab
@@ -27,7 +27,7 @@ Transform:
   m_GameObject: {fileID: 2496598836070849720}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -3.1, y: -0.352, z: 0}
+  m_LocalPosition: {x: -3.1, y: -0.386, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -52,7 +52,7 @@ BoxCollider:
   m_ProvidesContacts: 0
   m_Enabled: 1
   serializedVersion: 3
-  m_Size: {x: 6, y: 0.01, z: 1}
+  m_Size: {x: 6, y: 0.1, z: 1}
   m_Center: {x: 0, y: 0, z: 0}
 --- !u!114 &7236665951745719938
 MonoBehaviour:
@@ -163,7 +163,7 @@ Transform:
   m_GameObject: {fileID: 5834966620958852708}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -4.8, y: 0.778, z: 0}
+  m_LocalPosition: {x: -4.8, y: 0.708, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -340,7 +340,7 @@ Transform:
   m_GameObject: {fileID: 8848017957926763470}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 1.1, y: 0.373, z: 0}
+  m_LocalPosition: {x: -3.4, y: 0.413, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []

--- a/Assets/LTH/Prefabs/NPC.prefab
+++ b/Assets/LTH/Prefabs/NPC.prefab
@@ -124,6 +124,140 @@ MonoBehaviour:
   dialoguePanel: {fileID: 7601238558217261921}
   dialogueText: {fileID: 1190685726749781586}
   message: Welcome To My Game
+--- !u!1 &5199915968449631128
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6919886075253999915}
+  - component: {fileID: 7998540150843753736}
+  - component: {fileID: 4497614677032557775}
+  m_Layer: 5
+  m_Name: InteractionText
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!224 &6919886075253999915
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5199915968449631128}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1435525299987196826}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -700, y: -253}
+  m_SizeDelta: {x: 200.1, y: 180.1}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &7998540150843753736
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5199915968449631128}
+  m_CullTransparentMesh: 1
+--- !u!114 &4497614677032557775
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5199915968449631128}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: Do you want interaction? Continue "F"
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4278190080
+  m_fontColor: {r: 0, g: 0, b: 0, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 50
+  m_fontSizeBase: 50
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 1
+  m_HorizontalAlignment: 1
+  m_VerticalAlignment: 256
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: -150.75014, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
 --- !u!1 &7601238558217261921
 GameObject:
   m_ObjectHideFlags: 0
@@ -156,6 +290,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 7292657155267353316}
+  - {fileID: 6919886075253999915}
   m_Father: {fileID: 195096294172421257}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
@@ -238,7 +373,7 @@ GameObject:
   - component: {fileID: 939610965215423905}
   - component: {fileID: 1190685726749781586}
   m_Layer: 5
-  m_Name: Text (TMP)
+  m_Name: ConversationText
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -293,8 +428,9 @@ MonoBehaviour:
       m_Calls: []
   m_text: 
   m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
-  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontAsset: {fileID: 11400000, guid: 34396ba8f7c7d9b418213751b122d4eb, type: 2}
+  m_sharedMaterial: {fileID: -5286010542340893477, guid: 34396ba8f7c7d9b418213751b122d4eb,
+    type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
   m_fontMaterials: []
@@ -324,7 +460,7 @@ MonoBehaviour:
   m_enableAutoSizing: 0
   m_fontSizeMin: 18
   m_fontSizeMax: 72
-  m_fontStyle: 0
+  m_fontStyle: 1
   m_HorizontalAlignment: 2
   m_VerticalAlignment: 256
   m_textAlignment: 65535

--- a/Assets/LTH/Scenes/LTHScene.unity
+++ b/Assets/LTH/Scenes/LTHScene.unity
@@ -2617,21 +2617,6 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 0}
     m_Modifications:
-    - target: {fileID: 21908281371710282, guid: c6f7a37fbb903574eb200064d5a65340,
-        type: 3}
-      propertyPath: isLeftLadder
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1510158399109688200, guid: c6f7a37fbb903574eb200064d5a65340,
-        type: 3}
-      propertyPath: m_Center.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1893380573205794118, guid: c6f7a37fbb903574eb200064d5a65340,
-        type: 3}
-      propertyPath: isLeftLadder
-      value: 1
-      objectReference: {fileID: 0}
     - target: {fileID: 3289674125148539319, guid: c6f7a37fbb903574eb200064d5a65340,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -2682,45 +2667,10 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3527644150192820067, guid: c6f7a37fbb903574eb200064d5a65340,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 0.7071068
-      objectReference: {fileID: 0}
-    - target: {fileID: 3527644150192820067, guid: c6f7a37fbb903574eb200064d5a65340,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3527644150192820067, guid: c6f7a37fbb903574eb200064d5a65340,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0.7071068
-      objectReference: {fileID: 0}
-    - target: {fileID: 3527644150192820067, guid: c6f7a37fbb903574eb200064d5a65340,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3527644150192820067, guid: c6f7a37fbb903574eb200064d5a65340,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 90
-      objectReference: {fileID: 0}
-    - target: {fileID: 4373077509933759324, guid: c6f7a37fbb903574eb200064d5a65340,
-        type: 3}
-      propertyPath: isLeftLadder
-      value: 1
-      objectReference: {fileID: 0}
     - target: {fileID: 7885561848764964684, guid: c6f7a37fbb903574eb200064d5a65340,
         type: 3}
       propertyPath: m_Name
       value: Ladder_Left
-      objectReference: {fileID: 0}
-    - target: {fileID: 8226180750106850720, guid: c6f7a37fbb903574eb200064d5a65340,
-        type: 3}
-      propertyPath: isLeftLadder
-      value: 1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
@@ -2877,6 +2827,11 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 4989823276277799774, guid: 7ba90d0a1f645ba4b8fd0597dac26ca0,
+        type: 3}
+      propertyPath: m_Enabled
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 5105600736844585329, guid: 7ba90d0a1f645ba4b8fd0597dac26ca0,
         type: 3}
       propertyPath: m_Name

--- a/Assets/LTH/Scenes/LTHScene.unity
+++ b/Assets/LTH/Scenes/LTHScene.unity
@@ -559,6 +559,136 @@ MonoBehaviour:
   m_hasFontAssetChanged: 1
   m_baseMaterial: {fileID: 0}
   m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!1 &319931033
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 319931035}
+  - component: {fileID: 319931034}
+  m_Layer: 0
+  m_Name: SpawnManager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &319931034
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 319931033}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cb81f5a518d0dd54db8ef2f06d2a1462, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  spawnRules:
+  - spawnPoint: {fileID: 400970017}
+    gradeEntries:
+    - grade: 0
+      probability: 0.5
+      items:
+      - {fileID: 11400000, guid: b1a993f0fd1075649840f7f536a3df9e, type: 2}
+      - {fileID: 11400000, guid: 0525198294084e41da0f5bfcde68159c, type: 2}
+    - grade: 2
+      probability: 0.2
+      items:
+      - {fileID: 11400000, guid: e06c1a07c1c388b9e967e61c9b9f2c8f, type: 2}
+      - {fileID: 11400000, guid: 3c002d8c926e11e79b7f34f0049333c5, type: 2}
+  - spawnPoint: {fileID: 444154452}
+    gradeEntries:
+    - grade: 0
+      probability: 0.6
+      items:
+      - {fileID: 11400000, guid: 64d3c3e93b6b24c6db239f3ead48a8b8, type: 2}
+      - {fileID: 11400000, guid: 290b5e5916cfb1644b8e6e671124d4f5, type: 2}
+    - grade: 1
+      probability: 0.2
+      items:
+      - {fileID: 11400000, guid: 4a16e2d7f3955160b8595e94b29b5afd, type: 2}
+--- !u!4 &319931035
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 319931033}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 4.9065323, y: -2.3318217, z: 12.181654}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &400970016
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 400970017}
+  m_Layer: 0
+  m_Name: SpawnPoint1
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &400970017
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 400970016}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 4.36, y: 0, z: -2.863}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &444154451
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 444154452}
+  m_Layer: 0
+  m_Name: SpawnPoint2
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &444154452
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 444154451}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -1.59, y: 0, z: -2.863}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &512076749
 GameObject:
   m_ObjectHideFlags: 0
@@ -2914,3 +3044,6 @@ SceneRoots:
   - {fileID: 1518046201}
   - {fileID: 1831529015}
   - {fileID: 611841390}
+  - {fileID: 319931035}
+  - {fileID: 400970017}
+  - {fileID: 444154452}

--- a/Assets/LTH/Scenes/LTHScene.unity
+++ b/Assets/LTH/Scenes/LTHScene.unity
@@ -607,7 +607,7 @@ MonoBehaviour:
       items:
       - {fileID: 11400000, guid: 290b5e5916cfb1644b8e6e671124d4f5, type: 2}
     - grade: 1
-      probability: 0.2
+      probability: 0.5
       items:
       - {fileID: 11400000, guid: 4a16e2d7f3955160b8595e94b29b5afd, type: 2}
 --- !u!4 &319931035
@@ -785,7 +785,7 @@ Transform:
   m_GameObject: {fileID: 545219452}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 1.32, y: 1, z: -10.785}
+  m_LocalPosition: {x: 1.28, y: 1, z: -10.785}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
@@ -1313,7 +1313,7 @@ Transform:
   m_GameObject: {fileID: 780484701}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: -0.00003482915, w: 1}
-  m_LocalPosition: {x: 1.32, y: 1, z: -10.785}
+  m_LocalPosition: {x: 1.28, y: 1, z: -10.785}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -1827,7 +1827,7 @@ Transform:
   m_GameObject: {fileID: 1408900883}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 21.72, y: 0.47, z: 0.1}
+  m_LocalPosition: {x: 21.72, y: 0.47, z: 13.92}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
@@ -2609,6 +2609,124 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 854850bffd91dfe469cd53dca30e0c8f, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1001 &2435271169205808786
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 21908281371710282, guid: c6f7a37fbb903574eb200064d5a65340,
+        type: 3}
+      propertyPath: isLeftLadder
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1510158399109688200, guid: c6f7a37fbb903574eb200064d5a65340,
+        type: 3}
+      propertyPath: m_Center.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1893380573205794118, guid: c6f7a37fbb903574eb200064d5a65340,
+        type: 3}
+      propertyPath: isLeftLadder
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3289674125148539319, guid: c6f7a37fbb903574eb200064d5a65340,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 11
+      objectReference: {fileID: 0}
+    - target: {fileID: 3289674125148539319, guid: c6f7a37fbb903574eb200064d5a65340,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3289674125148539319, guid: c6f7a37fbb903574eb200064d5a65340,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -2.774313
+      objectReference: {fileID: 0}
+    - target: {fileID: 3289674125148539319, guid: c6f7a37fbb903574eb200064d5a65340,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 3289674125148539319, guid: c6f7a37fbb903574eb200064d5a65340,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3289674125148539319, guid: c6f7a37fbb903574eb200064d5a65340,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 3289674125148539319, guid: c6f7a37fbb903574eb200064d5a65340,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3289674125148539319, guid: c6f7a37fbb903574eb200064d5a65340,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3289674125148539319, guid: c6f7a37fbb903574eb200064d5a65340,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 90
+      objectReference: {fileID: 0}
+    - target: {fileID: 3289674125148539319, guid: c6f7a37fbb903574eb200064d5a65340,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3527644150192820067, guid: c6f7a37fbb903574eb200064d5a65340,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 3527644150192820067, guid: c6f7a37fbb903574eb200064d5a65340,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3527644150192820067, guid: c6f7a37fbb903574eb200064d5a65340,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 3527644150192820067, guid: c6f7a37fbb903574eb200064d5a65340,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3527644150192820067, guid: c6f7a37fbb903574eb200064d5a65340,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 90
+      objectReference: {fileID: 0}
+    - target: {fileID: 4373077509933759324, guid: c6f7a37fbb903574eb200064d5a65340,
+        type: 3}
+      propertyPath: isLeftLadder
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7885561848764964684, guid: c6f7a37fbb903574eb200064d5a65340,
+        type: 3}
+      propertyPath: m_Name
+      value: Ladder_Left
+      objectReference: {fileID: 0}
+    - target: {fileID: 8226180750106850720, guid: c6f7a37fbb903574eb200064d5a65340,
+        type: 3}
+      propertyPath: isLeftLadder
+      value: 1
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: c6f7a37fbb903574eb200064d5a65340, type: 3}
 --- !u!4 &2577591918035041140 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 6178594860655464899, guid: 7ba90d0a1f645ba4b8fd0597dac26ca0,
@@ -2636,7 +2754,7 @@ PrefabInstance:
     - target: {fileID: 195096294172421257, guid: a9a9f08c25501b747add5da276bf9477,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: -2.66
+      value: 10.99
       objectReference: {fileID: 0}
     - target: {fileID: 195096294172421257, guid: a9a9f08c25501b747add5da276bf9477,
         type: 3}
@@ -2767,7 +2885,7 @@ PrefabInstance:
     - target: {fileID: 6178594860655464899, guid: 7ba90d0a1f645ba4b8fd0597dac26ca0,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 1.32
+      value: 1.28
       objectReference: {fileID: 0}
     - target: {fileID: 6178594860655464899, guid: 7ba90d0a1f645ba4b8fd0597dac26ca0,
         type: 3}
@@ -2839,3 +2957,4 @@ SceneRoots:
   - {fileID: 611841390}
   - {fileID: 319931035}
   - {fileID: 7319970167086366107}
+  - {fileID: 2435271169205808786}

--- a/Assets/LTH/Scenes/LTHScene.unity
+++ b/Assets/LTH/Scenes/LTHScene.unity
@@ -570,7 +570,7 @@ GameObject:
   - component: {fileID: 319931035}
   - component: {fileID: 319931034}
   m_Layer: 0
-  m_Name: SpawnManager
+  m_Name: ItemSpawner
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -600,13 +600,11 @@ MonoBehaviour:
       probability: 0.2
       items:
       - {fileID: 11400000, guid: e06c1a07c1c388b9e967e61c9b9f2c8f, type: 2}
-      - {fileID: 11400000, guid: 3c002d8c926e11e79b7f34f0049333c5, type: 2}
   - spawnPoint: {fileID: 444154452}
     gradeEntries:
     - grade: 0
       probability: 0.6
       items:
-      - {fileID: 11400000, guid: 64d3c3e93b6b24c6db239f3ead48a8b8, type: 2}
       - {fileID: 11400000, guid: 290b5e5916cfb1644b8e6e671124d4f5, type: 2}
     - grade: 1
       probability: 0.2
@@ -624,7 +622,9 @@ Transform:
   m_LocalPosition: {x: 4.9065323, y: -2.3318217, z: 12.181654}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
-  m_Children: []
+  m_Children:
+  - {fileID: 400970017}
+  - {fileID: 444154452}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &400970016
@@ -651,12 +651,12 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 400970016}
   serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 4.36, y: 0, z: -2.863}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -5.892, y: 2.3318217, z: -15.044654}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 0}
+  m_Father: {fileID: 319931035}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &444154451
 GameObject:
@@ -682,12 +682,12 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 444154451}
   serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -1.59, y: 0, z: -2.863}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -6.4965324, y: 2.3318217, z: -15.044654}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 0}
+  m_Father: {fileID: 319931035}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &512076749
 GameObject:
@@ -785,7 +785,7 @@ Transform:
   m_GameObject: {fileID: 545219452}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 1.38, y: 1, z: -10.785}
+  m_LocalPosition: {x: 1.32, y: 1, z: -10.785}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
@@ -1313,7 +1313,7 @@ Transform:
   m_GameObject: {fileID: 780484701}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: -0.00003482915, w: 1}
-  m_LocalPosition: {x: 1.38, y: 1, z: -10.785}
+  m_LocalPosition: {x: 1.32, y: 1, z: -10.785}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -1474,12 +1474,6 @@ MonoBehaviour:
   m_OnClick:
     m_PersistentCalls:
       m_Calls: []
---- !u!224 &926663916 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 1435525299987196826, guid: a9a9f08c25501b747add5da276bf9477,
-    type: 3}
-  m_PrefabInstance: {fileID: 7287905782544205707}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1038314913
 GameObject:
   m_ObjectHideFlags: 0
@@ -1833,7 +1827,7 @@ Transform:
   m_GameObject: {fileID: 1408900883}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 9.88, y: 4.5, z: 0.1}
+  m_LocalPosition: {x: 21.72, y: 0.47, z: 0.1}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
@@ -1966,7 +1960,7 @@ Transform:
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 8.35, y: 1.96, z: -2.8}
-  m_LocalScale: {x: 5, y: 4, z: 5}
+  m_LocalScale: {x: 5, y: 4.3, z: 5}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
@@ -2571,140 +2565,6 @@ MonoBehaviour:
   m_hasFontAssetChanged: 1
   m_baseMaterial: {fileID: 0}
   m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
---- !u!1 &2024730738
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2024730739}
-  - component: {fileID: 2024730741}
-  - component: {fileID: 2024730740}
-  m_Layer: 5
-  m_Name: InteractionText
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 0
---- !u!224 &2024730739
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2024730738}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 926663916}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -700, y: -253}
-  m_SizeDelta: {x: 200.1, y: 180.1}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &2024730740
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2024730738}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_text: Do you want interaction? Continue "F"
-  m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
-  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
-  m_fontSharedMaterials: []
-  m_fontMaterial: {fileID: 0}
-  m_fontMaterials: []
-  m_fontColor32:
-    serializedVersion: 2
-    rgba: 4278190080
-  m_fontColor: {r: 0, g: 0, b: 0, a: 1}
-  m_enableVertexGradient: 0
-  m_colorMode: 3
-  m_fontColorGradient:
-    topLeft: {r: 1, g: 1, b: 1, a: 1}
-    topRight: {r: 1, g: 1, b: 1, a: 1}
-    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
-    bottomRight: {r: 1, g: 1, b: 1, a: 1}
-  m_fontColorGradientPreset: {fileID: 0}
-  m_spriteAsset: {fileID: 0}
-  m_tintAllSprites: 0
-  m_StyleSheet: {fileID: 0}
-  m_TextStyleHashCode: -1183493901
-  m_overrideHtmlColors: 0
-  m_faceColor:
-    serializedVersion: 2
-    rgba: 4294967295
-  m_fontSize: 50
-  m_fontSizeBase: 50
-  m_fontWeight: 400
-  m_enableAutoSizing: 0
-  m_fontSizeMin: 18
-  m_fontSizeMax: 72
-  m_fontStyle: 1
-  m_HorizontalAlignment: 1
-  m_VerticalAlignment: 256
-  m_textAlignment: 65535
-  m_characterSpacing: 0
-  m_wordSpacing: 0
-  m_lineSpacing: 0
-  m_lineSpacingMax: 0
-  m_paragraphSpacing: 0
-  m_charWidthMaxAdj: 0
-  m_enableWordWrapping: 1
-  m_wordWrappingRatios: 0.4
-  m_overflowMode: 0
-  m_linkedTextComponent: {fileID: 0}
-  parentLinkedComponent: {fileID: 0}
-  m_enableKerning: 1
-  m_enableExtraPadding: 0
-  checkPaddingRequired: 0
-  m_isRichText: 1
-  m_parseCtrlCharacters: 1
-  m_isOrthographic: 1
-  m_isCullingEnabled: 0
-  m_horizontalMapping: 0
-  m_verticalMapping: 0
-  m_uvLineOffset: 0
-  m_geometrySortingOrder: 0
-  m_IsTextObjectScaleStatic: 0
-  m_VertexBufferAutoSizeReduction: 0
-  m_useMaxVisibleDescender: 1
-  m_pageToDisplay: 1
-  m_margin: {x: 0, y: 0, z: -150.75014, w: 0}
-  m_isUsingLegacyAnimationComponent: 0
-  m_isVolumetricText: 0
-  m_hasFontAssetChanged: 0
-  m_baseMaterial: {fileID: 0}
-  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
---- !u!222 &2024730741
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2024730738}
-  m_CullTransparentMesh: 1
 --- !u!1 &2104429252
 GameObject:
   m_ObjectHideFlags: 0
@@ -2749,99 +2609,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 854850bffd91dfe469cd53dca30e0c8f, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!1001 &665143346453447277
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 1608049495101086003, guid: 4f324ea3110460a41b4e151144f47a06,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 5.81
-      objectReference: {fileID: 0}
-    - target: {fileID: 1608049495101086003, guid: 4f324ea3110460a41b4e151144f47a06,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 2.3
-      objectReference: {fileID: 0}
-    - target: {fileID: 1608049495101086003, guid: 4f324ea3110460a41b4e151144f47a06,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: -2.75
-      objectReference: {fileID: 0}
-    - target: {fileID: 1608049495101086003, guid: 4f324ea3110460a41b4e151144f47a06,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1608049495101086003, guid: 4f324ea3110460a41b4e151144f47a06,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1608049495101086003, guid: 4f324ea3110460a41b4e151144f47a06,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1608049495101086003, guid: 4f324ea3110460a41b4e151144f47a06,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1608049495101086003, guid: 4f324ea3110460a41b4e151144f47a06,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1608049495101086003, guid: 4f324ea3110460a41b4e151144f47a06,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1608049495101086003, guid: 4f324ea3110460a41b4e151144f47a06,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1887576124867095518, guid: 4f324ea3110460a41b4e151144f47a06,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0.708
-      objectReference: {fileID: 0}
-    - target: {fileID: 3439813621749343934, guid: 4f324ea3110460a41b4e151144f47a06,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -3.4
-      objectReference: {fileID: 0}
-    - target: {fileID: 3439813621749343934, guid: 4f324ea3110460a41b4e151144f47a06,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0.413
-      objectReference: {fileID: 0}
-    - target: {fileID: 5406579052772893354, guid: 4f324ea3110460a41b4e151144f47a06,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -0.386
-      objectReference: {fileID: 0}
-    - target: {fileID: 6657896853485947160, guid: 4f324ea3110460a41b4e151144f47a06,
-        type: 3}
-      propertyPath: m_Name
-      value: Ladder
-      objectReference: {fileID: 0}
-    - target: {fileID: 6749063416974342074, guid: 4f324ea3110460a41b4e151144f47a06,
-        type: 3}
-      propertyPath: m_Size.y
-      value: 0.1
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 4f324ea3110460a41b4e151144f47a06, type: 3}
 --- !u!4 &2577591918035041140 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 6178594860655464899, guid: 7ba90d0a1f645ba4b8fd0597dac26ca0,
@@ -2859,12 +2626,12 @@ PrefabInstance:
     - target: {fileID: 195096294172421257, guid: a9a9f08c25501b747add5da276bf9477,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 10.45
+      value: 23.82
       objectReference: {fileID: 0}
     - target: {fileID: 195096294172421257, guid: a9a9f08c25501b747add5da276bf9477,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 4.95
+      value: 1.11
       objectReference: {fileID: 0}
     - target: {fileID: 195096294172421257, guid: a9a9f08c25501b747add5da276bf9477,
         type: 3}
@@ -2906,47 +2673,84 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1190685726749781586, guid: a9a9f08c25501b747add5da276bf9477,
-        type: 3}
-      propertyPath: m_fontAsset
-      value: 
-      objectReference: {fileID: 11400000, guid: 34396ba8f7c7d9b418213751b122d4eb,
-        type: 2}
-    - target: {fileID: 1190685726749781586, guid: a9a9f08c25501b747add5da276bf9477,
-        type: 3}
-      propertyPath: m_fontStyle
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1190685726749781586, guid: a9a9f08c25501b747add5da276bf9477,
-        type: 3}
-      propertyPath: m_sharedMaterial
-      value: 
-      objectReference: {fileID: -5286010542340893477, guid: 34396ba8f7c7d9b418213751b122d4eb,
-        type: 2}
-    - target: {fileID: 1190685726749781586, guid: a9a9f08c25501b747add5da276bf9477,
-        type: 3}
-      propertyPath: m_hasFontAssetChanged
-      value: 0
-      objectReference: {fileID: 0}
     - target: {fileID: 3971455842172066244, guid: a9a9f08c25501b747add5da276bf9477,
         type: 3}
       propertyPath: m_Name
       value: NPC
       objectReference: {fileID: 0}
-    - target: {fileID: 7944763848412340939, guid: a9a9f08c25501b747add5da276bf9477,
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: a9a9f08c25501b747add5da276bf9477, type: 3}
+--- !u!1001 &7319970167086366107
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 3410208210069620777, guid: 679c2382f99916c46b9be84d9ba799ea,
         type: 3}
       propertyPath: m_Name
-      value: ConversationText
+      value: Ladder
+      objectReference: {fileID: 0}
+    - target: {fileID: 4619838059004417217, guid: 679c2382f99916c46b9be84d9ba799ea,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 5.76
+      objectReference: {fileID: 0}
+    - target: {fileID: 4619838059004417217, guid: 679c2382f99916c46b9be84d9ba799ea,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.00000023841858
+      objectReference: {fileID: 0}
+    - target: {fileID: 4619838059004417217, guid: 679c2382f99916c46b9be84d9ba799ea,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -2.74
+      objectReference: {fileID: 0}
+    - target: {fileID: 4619838059004417217, guid: 679c2382f99916c46b9be84d9ba799ea,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 4619838059004417217, guid: 679c2382f99916c46b9be84d9ba799ea,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4619838059004417217, guid: 679c2382f99916c46b9be84d9ba799ea,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 4619838059004417217, guid: 679c2382f99916c46b9be84d9ba799ea,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4619838059004417217, guid: 679c2382f99916c46b9be84d9ba799ea,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4619838059004417217, guid: 679c2382f99916c46b9be84d9ba799ea,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -90
+      objectReference: {fileID: 0}
+    - target: {fileID: 4619838059004417217, guid: 679c2382f99916c46b9be84d9ba799ea,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
-    m_AddedGameObjects:
-    - targetCorrespondingSourceObject: {fileID: 1435525299987196826, guid: a9a9f08c25501b747add5da276bf9477,
-        type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 2024730739}
+    m_AddedGameObjects: []
     m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: a9a9f08c25501b747add5da276bf9477, type: 3}
+  m_SourcePrefab: {fileID: 100100000, guid: 679c2382f99916c46b9be84d9ba799ea, type: 3}
 --- !u!1001 &8285911174895119357
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -2963,7 +2767,7 @@ PrefabInstance:
     - target: {fileID: 6178594860655464899, guid: 7ba90d0a1f645ba4b8fd0597dac26ca0,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 1.38
+      value: 1.32
       objectReference: {fileID: 0}
     - target: {fileID: 6178594860655464899, guid: 7ba90d0a1f645ba4b8fd0597dac26ca0,
         type: 3}
@@ -3010,16 +2814,6 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8051579310240518305, guid: 7ba90d0a1f645ba4b8fd0597dac26ca0,
-        type: 3}
-      propertyPath: interactLayerNames.Array.size
-      value: 4
-      objectReference: {fileID: 0}
-    - target: {fileID: 8051579310240518305, guid: 7ba90d0a1f645ba4b8fd0597dac26ca0,
-        type: 3}
-      propertyPath: interactLayerNames.Array.data[3]
-      value: Teleport
-      objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
@@ -3039,11 +2833,9 @@ SceneRoots:
   - {fileID: 7287905782544205707}
   - {fileID: 1844893228}
   - {fileID: 581573207}
-  - {fileID: 665143346453447277}
   - {fileID: 8285911174895119357}
   - {fileID: 1518046201}
   - {fileID: 1831529015}
   - {fileID: 611841390}
   - {fileID: 319931035}
-  - {fileID: 400970017}
-  - {fileID: 444154452}
+  - {fileID: 7319970167086366107}

--- a/Assets/LTH/Scripts/Interactions/Ladder/LadderClimber.cs
+++ b/Assets/LTH/Scripts/Interactions/Ladder/LadderClimber.cs
@@ -16,6 +16,7 @@ public class LadderClimber
         this.onClimbEndFromTop = onClimbEndFromTop;
     }
 
+
     public void Climb(Vector3 moveInput, bool isGrounded, bool isAtTop)
     {
         Vector3 targetVelocity = Vector3.up * moveInput.y * _climbSpeed;

--- a/Assets/LTH/Scripts/Interactions/Ladder/LadderTrigger.cs
+++ b/Assets/LTH/Scripts/Interactions/Ladder/LadderTrigger.cs
@@ -11,7 +11,8 @@ public enum LadderTriggerType
 public class LadderTrigger : MonoBehaviour, IInteractable
 {
     [HideInInspector] public LadderTriggerType triggerType;
-    [SerializeField] public float enterDistance = 1.1f;
+    [SerializeField] public float enterDistance = 1.2f;
+    [SerializeField] private bool isLeftLadder = false;
 
     private PlayerMovement player;
 
@@ -62,31 +63,21 @@ public class LadderTrigger : MonoBehaviour, IInteractable
 
     public void Interact()
     {
-        if (player == null)
-        {
-            return;
-        }
+        if (player == null) return;
 
-        float dist = Vector3.Distance(transform.position, player.transform.position);
-
-        if (dist > enterDistance)
-        {
-            return;
-        }
+        Vector3 climbDirection = isLeftLadder ? Vector3.left : Vector3.right;
 
         switch (triggerType)
         {
             case LadderTriggerType.EnterBottom:
             case LadderTriggerType.EnterTop:
-                player.StartClimbing(transform.position, transform.forward, triggerType);
+                player.StartClimbing(transform.position, climbDirection, triggerType);
                 break;
 
             case LadderTriggerType.ExitBottom:
             case LadderTriggerType.ExitTop:
                 if (player.IsOnLadder)
-                {
                     player.EndClimb();
-                }
                 break;
         }
     }

--- a/Assets/LTH/Scripts/Items/ItemGrade.cs
+++ b/Assets/LTH/Scripts/Items/ItemGrade.cs
@@ -1,0 +1,7 @@
+public enum ItemGrade
+{
+    Common,
+    Rare,
+    Epic,
+    Legendary
+}

--- a/Assets/LTH/Scripts/Items/ItemGrade.cs.meta
+++ b/Assets/LTH/Scripts/Items/ItemGrade.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: cdea1397d6baf6b49908afe734f41cc7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/LTH/Scripts/Items/ItemProbabilityEntry.cs
+++ b/Assets/LTH/Scripts/Items/ItemProbabilityEntry.cs
@@ -1,0 +1,18 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace LTH
+{
+    [Serializable]
+    public class ItemProbabilityEntry
+    {
+        public ItemGrade grade;
+
+        [Range(0f, 1f)]
+        public float probability;
+
+        public List<ItemData> items;
+    }
+}
+

--- a/Assets/LTH/Scripts/Items/ItemProbabilityEntry.cs.meta
+++ b/Assets/LTH/Scripts/Items/ItemProbabilityEntry.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2f8a35a5e2439ab4ab80354278efc7a1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/LTH/Scripts/Items/ItemSpawnRule.cs
+++ b/Assets/LTH/Scripts/Items/ItemSpawnRule.cs
@@ -1,0 +1,13 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace LTH
+{
+    [Serializable]
+    public class ItemSpawnRule
+    {
+        public Transform spawnPoint;
+        public List<ItemProbabilityEntry> gradeEntries;
+    }
+}

--- a/Assets/LTH/Scripts/Items/ItemSpawnRule.cs.meta
+++ b/Assets/LTH/Scripts/Items/ItemSpawnRule.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6dfc16df7bac25340b0796c03462354c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/LTH/Scripts/Items/ProbabilityItemSpawner.cs
+++ b/Assets/LTH/Scripts/Items/ProbabilityItemSpawner.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Data;
+using UnityEngine;
+
+
+namespace LTH
+{
+    public class ProbabilityItemSpawner : MonoBehaviour
+    {
+        [SerializeField] private List<ItemSpawnRule> spawnRules;
+
+        private readonly HashSet<Transform> usedSpawnPoints = new();
+
+        private void Start()
+        {
+            SpawnAll();
+        }
+
+        public void SpawnAll()
+        {
+            foreach (var rule in spawnRules)
+            {
+                var selectedGrade = ChooseGrade(rule.gradeEntries);
+                if (selectedGrade == null || selectedGrade.items.Count == 0) continue;
+
+                var item = selectedGrade.items[UnityEngine.Random.Range(0, selectedGrade.items.Count)];
+
+                GameObject instance = Instantiate(item.Prefab);
+                instance.transform.position = rule.spawnPoint.position;
+
+                if (instance.TryGetComponent<ItemObject>(out var itemObject))
+                {
+                    itemObject.SetItem(Item.CreateItemFrom(item));
+                }
+            }
+        }
+
+        private ItemProbabilityEntry ChooseGrade(List<ItemProbabilityEntry> grades)
+        {
+            float rand = UnityEngine.Random.value;
+            float cumulative = 0f;
+
+            foreach (var entry in grades)
+            {
+                cumulative += entry.probability;
+                if (rand <= cumulative)
+                {
+                    return entry;
+                }
+            }
+            return null;
+        }
+    }
+}

--- a/Assets/LTH/Scripts/Items/ProbabilityItemSpawner.cs.meta
+++ b/Assets/LTH/Scripts/Items/ProbabilityItemSpawner.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: cb81f5a518d0dd54db8ef2f06d2a1462
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/LTH/Scripts/Player/PlayerTeleportDetector.cs
+++ b/Assets/LTH/Scripts/Player/PlayerTeleportDetector.cs
@@ -1,0 +1,23 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class PlayerTeleportDetector : MonoBehaviour
+{
+    private PlayerMovement movement;
+
+    private void Start()
+    {
+        movement = GetComponent<PlayerMovement>();
+    }
+
+    private void OnTriggerEnter(Collider other)
+    {
+        if (other.gameObject.layer == LayerMask.NameToLayer("Teleport"))
+        {
+            movement.SetZFixed(false);
+            float teleportZ = other.transform.position.z;
+            movement.ForceZPosition(teleportZ);
+        }
+    }
+}

--- a/Assets/LTH/Scripts/Player/PlayerTeleportDetector.cs.meta
+++ b/Assets/LTH/Scripts/Player/PlayerTeleportDetector.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 28747d05b9eb903419e73e3fc1eef7df
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## 🧩 개요
- 이번 PR에서 변경된 핵심 내용을 간단히 적어주세요.
1. 아이템 스폰 요구사항 추가 및 개선
- 등급 도입
- 확률 도입
- 아이템이 겹치지 않고 하나만 나오도록 수정

 2. 사다리 버그
 사다리를 오른쪽에 접근했을 때와 왼쪽으로 접근했을 때 애니메이션이 동일하게 나오는 부분 수정

3. 순간 이동 버그
순간 이동 시 Z축이 아예 고정이 되어버리는 부분 수정

## 📁 변경 사항 체크리스트
- [x] C# 스크립트 추가/수정
- [x] 프리팹 변경
- [ ] 씬(.unity) 파일 변경
- [ ] 애니메이션/사운드 리소스 변경
- [ ] ScriptableObject 변경
- [ ] 기타 리소스 또는 설정 변경

## ✅ 확인 사항
- [x] Unity 에디터에서 정상 동작 확인
- [x] 관련 기능 플레이 테스트 완료
- [x] 에러/경고 없음
- [ ] 변경된 파일이 Git LFS 대상인지 확인 (필요시)
- [x] 충돌 방지를 위해 최신 develop/main 브랜치에서 작업

## 🧪 테스트 내역
- [x] 새 기능 직접 실행 확인
- [x] 씬 변경 시, 기존 오브젝트와 충돌 없음
- [ ] 멀티플레이/네트워크 관련 기능 확인 (해당 시)
- [ ] (선택) 커스텀 유닛/에디터 테스트 포함

## 📝 기타
- [ ] 변경된 프리팹/씬이 **Unity 외부에서**